### PR TITLE
Fix id longer than 63 bits

### DIFF
--- a/src/LaraFlake.php
+++ b/src/LaraFlake.php
@@ -45,7 +45,7 @@ class LaraFlake
         /**
         * Concatenate the final ID
         */
-        $final_id = bindec($base) . bindec($shard_id) . bindec($random_part);
+        $final_id = bindec($base . $shard_id . $random_part);
         /**
         * Return unique 64bit ID
         */


### PR DESCRIPTION
To make sure to have a real 63 bits number, we need to concat binaries values, then we can convert it to integer.
Because integers are always signed in PHP, we can only have a 63 bits number. (see [decbin function](http://php.net/manual/fr/function.decbin.php)).