### PR TITLE
prevent error on multiple excecution of boot function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ bootstrap/cache/
 
 # Rocketeer PHP task runner and deployment package. https://github.com/rocketeers/rocketeer
 .rocketeer/
+.idea

--- a/src/Traits/LaraFlakeTrait.php
+++ b/src/Traits/LaraFlakeTrait.php
@@ -2,20 +2,16 @@
 
 namespace Hafael\LaraFlake\Traits;
 
-
-
 use Hafael\LaraFlake\LaraFlake;
 
 trait LaraFlakeTrait
 {
-    protected static function boot()
+    protected static function bootLaraFlakeTrait()
     {
         parent::boot();
 
         static::creating(function($model){
-
             $model->{$model->getKeyName()} = LaraFlake::generateID();
-
         });
     }
 }


### PR DESCRIPTION
fix boot on the trait, prevent error on multiple `boot()` while use laraflake and implement global scope on the same model. 

Got error MySQL undefined default value for column `id` when using `LaraFlakeTrait` and call `boot()` function to implement global scope on the same model


refer to this https://www.archybold.com/blog/post/booting-eloquent-model-traits.